### PR TITLE
Add full PC booking flow: backend, UI, and tests

### DIFF
--- a/CyberZone.Application/DTOs/BookNowDto.cs
+++ b/CyberZone.Application/DTOs/BookNowDto.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel.DataAnnotations;
+using CyberZone.Domain.Enums;
+
+namespace CyberZone.Application.DTOs;
+
+/// <summary>
+/// Form model for booking a single PC from the club map.
+/// User picks a tariff, start time, and duration in hours.
+/// </summary>
+public class BookNowDto
+{
+    public Guid ClubId { get; set; }
+    public string? ClubName { get; set; }
+
+    public Guid HardwareId { get; set; }
+    public string? PcNumber { get; set; }
+
+    [Required]
+    public Guid TariffId { get; set; }
+
+    [Required]
+    public DateTime StartTime { get; set; } = DateTime.Now;
+
+    [Range(1, 24, ErrorMessage = "Тривалість має бути від 1 до 24 годин.")]
+    public int Hours { get; set; } = 1;
+
+    [StringLength(500)]
+    public string? Notes { get; set; }
+
+    // Populated on GET for the form dropdown.
+    public List<TariffOption> AvailableTariffs { get; set; } = [];
+
+    // Populated on GET to show the user their current balance.
+    public decimal UserBalance { get; set; }
+}
+
+public class TariffOption
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = null!;
+    public TariffType Type { get; set; }
+    public decimal PricePerHour { get; set; }
+}

--- a/CyberZone.Application/Interfaces/IApplicationDbContext.cs
+++ b/CyberZone.Application/Interfaces/IApplicationDbContext.cs
@@ -5,6 +5,7 @@ namespace CyberZone.Application.Interfaces;
 
 public interface IApplicationDbContext
 {
+    DbSet<User> Users { get; }
     DbSet<Club> Clubs { get; }
     DbSet<Hardware> Hardwares { get; }
     DbSet<Tariff> Tariffs { get; }

--- a/CyberZone.Application/Interfaces/IBookingService.cs
+++ b/CyberZone.Application/Interfaces/IBookingService.cs
@@ -1,0 +1,18 @@
+using CyberZone.Application.Common;
+using CyberZone.Application.DTOs;
+
+namespace CyberZone.Application.Interfaces;
+
+public interface IBookingService
+{
+    /// <summary>
+    /// Prepares the form model for /Booking/Create — tariffs, PC info, user balance.
+    /// </summary>
+    Task<Result<BookNowDto>> PrepareFormAsync(Guid userId, Guid clubId, Guid hardwareId);
+
+    /// <summary>
+    /// Validates the slot (PC available + not overlapping), charges the user balance,
+    /// and creates a Pending Booking.
+    /// </summary>
+    Task<Result<Guid>> CreateAsync(Guid userId, BookNowDto dto);
+}

--- a/CyberZone.Application/Interfaces/IPaymentService.cs
+++ b/CyberZone.Application/Interfaces/IPaymentService.cs
@@ -1,0 +1,11 @@
+using CyberZone.Domain.Entities;
+
+namespace CyberZone.Application.Interfaces;
+
+public interface IPaymentService
+{
+    Task<Transaction> TopUpAsync(Guid userId, decimal amount, string? description = null, CancellationToken ct = default);
+    Task<Transaction> ChargeSessionAsync(Guid userId, Guid sessionId, decimal amount, CancellationToken ct = default);
+    Task<Transaction> PayOrderAsync(Guid userId, Guid orderId, decimal amount, CancellationToken ct = default);
+    Task<Transaction> RefundAsync(Guid userId, decimal amount, Guid? referenceId = null, string? description = null, CancellationToken ct = default);
+}

--- a/CyberZone.Infrastructure/DependencyInjection.cs
+++ b/CyberZone.Infrastructure/DependencyInjection.cs
@@ -53,8 +53,10 @@ public static class DependencyInjection
 
         // Services
         services.AddScoped<PaymentService>();
+        services.AddScoped<IPaymentService>(sp => sp.GetRequiredService<PaymentService>());
         services.AddScoped<IClubService, ClubService>();
         services.AddScoped<IClubMapService, ClubMapService>();
+        services.AddScoped<IBookingService, BookingService>();
         services.AddScoped<PaymentService>();
         services.AddScoped<CyberZone.Application.Interfaces.IUserService, CyberZone.Infrastructure.Services.UserService>();
         services.AddScoped<IReviewService, ReviewService>();

--- a/CyberZone.Infrastructure/Services/BookingService.cs
+++ b/CyberZone.Infrastructure/Services/BookingService.cs
@@ -1,0 +1,151 @@
+using CyberZone.Application.Common;
+using CyberZone.Application.DTOs;
+using CyberZone.Application.Interfaces;
+using CyberZone.Domain.Entities;
+using CyberZone.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace CyberZone.Infrastructure.Services;
+
+public class BookingService : IBookingService
+{
+    private readonly IApplicationDbContext _context;
+    private readonly IPaymentService _payment;
+    private readonly ICacheService _cache;
+    private readonly ILogger<BookingService> _logger;
+
+    public BookingService(
+        IApplicationDbContext context,
+        IPaymentService payment,
+        ICacheService cache,
+        ILogger<BookingService> logger)
+    {
+        _context = context;
+        _payment = payment;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<Result<BookNowDto>> PrepareFormAsync(Guid userId, Guid clubId, Guid hardwareId)
+    {
+        var hardware = await _context.Hardwares
+            .AsNoTracking()
+            .FirstOrDefaultAsync(h => h.Id == hardwareId && h.ClubId == clubId);
+
+        if (hardware is null)
+            return Result.Failure<BookNowDto>("PC не знайдено для цього клубу.");
+
+        if (hardware.Status != HardwareStatus.Available)
+            return Result.Failure<BookNowDto>("PC зараз недоступний для бронювання.");
+
+        var club = await _context.Clubs.AsNoTracking().FirstOrDefaultAsync(c => c.Id == clubId);
+        if (club is null)
+            return Result.Failure<BookNowDto>("Клуб не знайдено.");
+
+        var tariffs = await _context.Tariffs
+            .AsNoTracking()
+            .Where(t => t.ClubId == clubId)
+            .OrderBy(t => t.PricePerHour)
+            .ToListAsync();
+
+        if (tariffs.Count == 0)
+            return Result.Failure<BookNowDto>("У клубі не налаштовано жодного тарифу.");
+
+        var user = await _context.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId);
+        if (user is null)
+            return Result.Failure<BookNowDto>("Користувача не знайдено.");
+
+        return Result.Success(new BookNowDto
+        {
+            ClubId = clubId,
+            ClubName = club.Name,
+            HardwareId = hardware.Id,
+            PcNumber = hardware.PcNumber,
+            TariffId = tariffs[0].Id,
+            StartTime = DateTime.Now,
+            Hours = 1,
+            AvailableTariffs = tariffs.Select(t => new TariffOption
+            {
+                Id = t.Id,
+                Name = t.Name,
+                Type = t.Type,
+                PricePerHour = t.PricePerHour
+            }).ToList(),
+            UserBalance = user.Balance
+        });
+    }
+
+    public async Task<Result<Guid>> CreateAsync(Guid userId, BookNowDto dto)
+    {
+        if (dto.Hours is < 1 or > 24)
+            return Result.Failure<Guid>("Тривалість має бути від 1 до 24 годин.");
+
+        if (dto.StartTime < DateTime.UtcNow.AddMinutes(-5))
+            return Result.Failure<Guid>("Час початку не може бути в минулому.");
+
+        var hardware = await _context.Hardwares
+            .FirstOrDefaultAsync(h => h.Id == dto.HardwareId && h.ClubId == dto.ClubId);
+        if (hardware is null)
+            return Result.Failure<Guid>("PC не знайдено для цього клубу.");
+
+        if (hardware.Status != HardwareStatus.Available)
+            return Result.Failure<Guid>("PC зараз недоступний для бронювання.");
+
+        var tariff = await _context.Tariffs
+            .FirstOrDefaultAsync(t => t.Id == dto.TariffId && t.ClubId == dto.ClubId);
+        if (tariff is null)
+            return Result.Failure<Guid>("Обраний тариф не належить цьому клубу.");
+
+        var user = await _context.Users.FirstOrDefaultAsync(u => u.Id == userId);
+        if (user is null)
+            return Result.Failure<Guid>("Користувача не знайдено.");
+
+        var startUtc = dto.StartTime.Kind == DateTimeKind.Utc ? dto.StartTime : dto.StartTime.ToUniversalTime();
+        var endUtc = startUtc.AddHours(dto.Hours);
+        var cost = Math.Round(tariff.PricePerHour * dto.Hours, 2);
+
+        if (user.Balance < cost)
+            return Result.Failure<Guid>($"Недостатньо коштів. Потрібно {cost:0.00} ₴, доступно {user.Balance:0.00} ₴.");
+
+        // Overlap: any active booking for the same PC that intersects [startUtc, endUtc).
+        // Pending / Confirmed / Active rezervуют PC. Cancelled and Completed уже не блокують.
+        // Active з минулою EndTime — це "висяк", теж ігноруємо (session вже могли завершити завчасно
+        // без оновлення booking.Status).
+        var now = DateTime.UtcNow;
+        var hasOverlap = await _context.Bookings.AnyAsync(b =>
+            b.HardwareId == dto.HardwareId
+            && b.Status != BookingStatus.Cancelled
+            && b.Status != BookingStatus.Completed
+            && !(b.Status == BookingStatus.Active && b.EndTime <= now)
+            && b.StartTime < endUtc
+            && b.EndTime > startUtc);
+
+        if (hasOverlap)
+            return Result.Failure<Guid>("На цей час PC уже заброньовано. Оберіть інший інтервал.");
+
+        var booking = new Booking
+        {
+            UserId = userId,
+            HardwareId = dto.HardwareId,
+            TariffId = dto.TariffId,
+            StartTime = startUtc,
+            EndTime = endUtc,
+            Status = BookingStatus.Pending,
+            Notes = dto.Notes
+        };
+        _context.Bookings.Add(booking);
+
+        await _payment.ChargeSessionAsync(userId, booking.Id, cost);
+        await _context.SaveChangesAsync();
+
+        _cache.Remove(CacheKeys.ClubMap(dto.ClubId));
+        _cache.Remove(CacheKeys.ClubDetails(dto.ClubId));
+
+        _logger.LogInformation(
+            "Booking {BookingId} created: user {UserId}, PC {HardwareId}, {Start}–{End}, cost {Cost}",
+            booking.Id, userId, dto.HardwareId, startUtc, endUtc, cost);
+
+        return Result.Success(booking.Id);
+    }
+}

--- a/CyberZone.Infrastructure/Services/PaymentService.cs
+++ b/CyberZone.Infrastructure/Services/PaymentService.cs
@@ -1,3 +1,4 @@
+using CyberZone.Application.Interfaces;
 using CyberZone.Domain.Entities;
 using CyberZone.Domain.Enums;
 using CyberZone.Infrastructure.Persistence;
@@ -6,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace CyberZone.Infrastructure.Services;
 
-public class PaymentService
+public class PaymentService : IPaymentService
 {
     private readonly CyberZoneDbContext _context;
     private readonly ILogger<PaymentService> _logger;

--- a/CyberZone.Tests/Infrastructure/Services/BookingServiceTests.cs
+++ b/CyberZone.Tests/Infrastructure/Services/BookingServiceTests.cs
@@ -1,0 +1,370 @@
+using CyberZone.Application.DTOs;
+using CyberZone.Application.Interfaces;
+using CyberZone.Domain.Entities;
+using CyberZone.Domain.Enums;
+using CyberZone.Infrastructure.Services;
+using CyberZone.Tests.Helpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace CyberZone.Tests.Infrastructure.Services;
+
+public class BookingServiceTests
+{
+    private readonly Mock<IApplicationDbContext> _mockContext;
+    private readonly Mock<IPaymentService> _mockPayment;
+    private readonly BookingService _service;
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _clubId = Guid.NewGuid();
+    private readonly Guid _hardwareId = Guid.NewGuid();
+    private readonly Guid _tariffId = Guid.NewGuid();
+
+    public BookingServiceTests()
+    {
+        _mockContext = new Mock<IApplicationDbContext>();
+        _mockPayment = new Mock<IPaymentService>();
+        var logger = new Mock<ILogger<BookingService>>();
+        _service = new BookingService(_mockContext.Object, _mockPayment.Object, new NoOpCacheService(), logger.Object);
+    }
+
+    // --- Fixtures ---
+
+    private User CreateUser(decimal balance = 1000m) =>
+        new() { Id = _userId, UserName = "testuser", Balance = balance };
+
+    private Hardware CreateHardware(HardwareStatus status = HardwareStatus.Available) =>
+        new() { Id = _hardwareId, ClubId = _clubId, PcNumber = "1", Status = status };
+
+    private Tariff CreateTariff(decimal price = 100m) =>
+        new() { Id = _tariffId, ClubId = _clubId, Name = "Standard", Type = TariffType.Hourly, PricePerHour = price };
+
+    private Club CreateClub() =>
+        new() { Id = _clubId, Name = "CyberPro Arena" };
+
+    private void Setup(
+        List<User>? users = null,
+        List<Club>? clubs = null,
+        List<Hardware>? hardwares = null,
+        List<Tariff>? tariffs = null,
+        List<Booking>? bookings = null)
+    {
+        _mockContext.Setup(c => c.Users).Returns(MockDbSetHelper.CreateMockDbSet(users ?? [CreateUser()]).Object);
+        _mockContext.Setup(c => c.Clubs).Returns(MockDbSetHelper.CreateMockDbSet(clubs ?? [CreateClub()]).Object);
+        _mockContext.Setup(c => c.Hardwares).Returns(MockDbSetHelper.CreateMockDbSet(hardwares ?? [CreateHardware()]).Object);
+        _mockContext.Setup(c => c.Tariffs).Returns(MockDbSetHelper.CreateMockDbSet(tariffs ?? [CreateTariff()]).Object);
+        _mockContext.Setup(c => c.Bookings).Returns(MockDbSetHelper.CreateMockDbSet(bookings ?? []).Object);
+    }
+
+    private BookNowDto ValidDto(int hours = 2) => new()
+    {
+        ClubId = _clubId,
+        HardwareId = _hardwareId,
+        TariffId = _tariffId,
+        StartTime = DateTime.UtcNow.AddHours(1),
+        Hours = hours
+    };
+
+    // ---------- PrepareFormAsync ----------
+
+    [Fact]
+    public async Task PrepareFormAsync_ValidInput_ReturnsSuccessWithTariffs()
+    {
+        Setup(tariffs: [CreateTariff(100m), new Tariff { Id = Guid.NewGuid(), ClubId = _clubId, Name = "Night", Type = TariffType.Night, PricePerHour = 75m }]);
+
+        var result = await _service.PrepareFormAsync(_userId, _clubId, _hardwareId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AvailableTariffs.Should().HaveCount(2);
+        result.Value.PcNumber.Should().Be("1");
+        result.Value.ClubName.Should().Be("CyberPro Arena");
+    }
+
+    [Fact]
+    public async Task PrepareFormAsync_ValidInput_ReturnsUserBalance()
+    {
+        Setup(users: [CreateUser(balance: 450m)]);
+
+        var result = await _service.PrepareFormAsync(_userId, _clubId, _hardwareId);
+
+        result.Value.UserBalance.Should().Be(450m);
+    }
+
+    [Fact]
+    public async Task PrepareFormAsync_HardwareNotFound_ReturnsFailure()
+    {
+        Setup(hardwares: []);
+
+        var result = await _service.PrepareFormAsync(_userId, _clubId, _hardwareId);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("PC");
+    }
+
+    [Fact]
+    public async Task PrepareFormAsync_HardwareBusy_ReturnsFailure()
+    {
+        Setup(hardwares: [CreateHardware(HardwareStatus.Busy)]);
+
+        var result = await _service.PrepareFormAsync(_userId, _clubId, _hardwareId);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("недоступний");
+    }
+
+    [Fact]
+    public async Task PrepareFormAsync_NoTariffs_ReturnsFailure()
+    {
+        Setup(tariffs: []);
+
+        var result = await _service.PrepareFormAsync(_userId, _clubId, _hardwareId);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("тариф");
+    }
+
+    [Fact]
+    public async Task PrepareFormAsync_UserNotFound_ReturnsFailure()
+    {
+        Setup(users: []);
+
+        var result = await _service.PrepareFormAsync(_userId, _clubId, _hardwareId);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PrepareFormAsync_ClubMismatch_ReturnsFailure()
+    {
+        var otherClubHw = new Hardware { Id = _hardwareId, ClubId = Guid.NewGuid(), PcNumber = "1", Status = HardwareStatus.Available };
+        Setup(hardwares: [otherClubHw]);
+
+        var result = await _service.PrepareFormAsync(_userId, _clubId, _hardwareId);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    // ---------- CreateAsync: validation ----------
+
+    [Fact]
+    public async Task CreateAsync_ZeroHours_ReturnsFailure()
+    {
+        Setup();
+        var dto = ValidDto(hours: 0);
+
+        var result = await _service.CreateAsync(_userId, dto);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("Тривалість");
+    }
+
+    [Fact]
+    public async Task CreateAsync_MoreThan24Hours_ReturnsFailure()
+    {
+        Setup();
+        var dto = ValidDto(hours: 25);
+
+        var result = await _service.CreateAsync(_userId, dto);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_StartTimeInPast_ReturnsFailure()
+    {
+        Setup();
+        var dto = ValidDto();
+        dto.StartTime = DateTime.UtcNow.AddHours(-2);
+
+        var result = await _service.CreateAsync(_userId, dto);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("минулому");
+    }
+
+    [Fact]
+    public async Task CreateAsync_HardwareNotFound_ReturnsFailure()
+    {
+        Setup(hardwares: []);
+
+        var result = await _service.CreateAsync(_userId, ValidDto());
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_HardwareBusy_ReturnsFailure()
+    {
+        Setup(hardwares: [CreateHardware(HardwareStatus.Busy)]);
+
+        var result = await _service.CreateAsync(_userId, ValidDto());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("недоступний");
+    }
+
+    [Fact]
+    public async Task CreateAsync_TariffFromDifferentClub_ReturnsFailure()
+    {
+        var foreignTariff = new Tariff { Id = _tariffId, ClubId = Guid.NewGuid(), Name = "Cheap", PricePerHour = 10m };
+        Setup(tariffs: [foreignTariff]);
+
+        var result = await _service.CreateAsync(_userId, ValidDto());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("тариф");
+    }
+
+    [Fact]
+    public async Task CreateAsync_InsufficientBalance_ReturnsFailure()
+    {
+        Setup(users: [CreateUser(balance: 50m)], tariffs: [CreateTariff(price: 100m)]);
+        var dto = ValidDto(hours: 2); // cost = 200, balance = 50
+
+        var result = await _service.CreateAsync(_userId, dto);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("Недостатньо");
+    }
+
+    [Fact]
+    public async Task CreateAsync_InsufficientBalance_DoesNotCharge()
+    {
+        Setup(users: [CreateUser(balance: 50m)], tariffs: [CreateTariff(price: 100m)]);
+
+        await _service.CreateAsync(_userId, ValidDto(hours: 2));
+
+        _mockPayment.Verify(p => p.ChargeSessionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---------- CreateAsync: overlap ----------
+
+    [Fact]
+    public async Task CreateAsync_OverlappingPendingBooking_ReturnsFailure()
+    {
+        var dto = ValidDto(hours: 2); // [now+1h .. now+3h]
+        var overlap = new Booking
+        {
+            HardwareId = _hardwareId,
+            StartTime = dto.StartTime.AddMinutes(30),
+            EndTime = dto.StartTime.AddHours(1).AddMinutes(30),
+            Status = BookingStatus.Pending
+        };
+        Setup(bookings: [overlap]);
+
+        var result = await _service.CreateAsync(_userId, dto);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("заброньовано");
+    }
+
+    [Fact]
+    public async Task CreateAsync_CancelledBooking_DoesNotBlock()
+    {
+        var dto = ValidDto(hours: 2);
+        var cancelled = new Booking
+        {
+            HardwareId = _hardwareId,
+            StartTime = dto.StartTime,
+            EndTime = dto.StartTime.AddHours(2),
+            Status = BookingStatus.Cancelled
+        };
+        Setup(bookings: [cancelled]);
+
+        var result = await _service.CreateAsync(_userId, dto);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_CompletedBooking_DoesNotBlock()
+    {
+        var dto = ValidDto(hours: 2);
+        var completed = new Booking
+        {
+            HardwareId = _hardwareId,
+            StartTime = dto.StartTime,
+            EndTime = dto.StartTime.AddHours(2),
+            Status = BookingStatus.Completed
+        };
+        Setup(bookings: [completed]);
+
+        var result = await _service.CreateAsync(_userId, dto);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_BookingOnDifferentPc_DoesNotBlock()
+    {
+        var dto = ValidDto(hours: 2);
+        var otherPc = new Booking
+        {
+            HardwareId = Guid.NewGuid(),
+            StartTime = dto.StartTime,
+            EndTime = dto.StartTime.AddHours(2),
+            Status = BookingStatus.Pending
+        };
+        Setup(bookings: [otherPc]);
+
+        var result = await _service.CreateAsync(_userId, dto);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_ActiveBookingWithPastEndTime_DoesNotBlock()
+    {
+        // User's previous session was ended early but booking.Status stayed Active.
+        // New booking for the same PC in the future must still succeed.
+        var dto = ValidDto(hours: 2);
+        var stale = new Booking
+        {
+            HardwareId = _hardwareId,
+            StartTime = DateTime.UtcNow.AddHours(-2),
+            EndTime = DateTime.UtcNow.AddMinutes(-5),
+            Status = BookingStatus.Active
+        };
+        Setup(bookings: [stale]);
+
+        var result = await _service.CreateAsync(_userId, dto);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    // ---------- CreateAsync: happy path ----------
+
+    [Fact]
+    public async Task CreateAsync_ValidInput_ReturnsSuccessWithBookingId()
+    {
+        Setup();
+
+        var result = await _service.CreateAsync(_userId, ValidDto());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ValidInput_ChargesUserForCorrectCost()
+    {
+        Setup(tariffs: [CreateTariff(price: 75m)]);
+
+        await _service.CreateAsync(_userId, ValidDto(hours: 3));
+
+        _mockPayment.Verify(
+            p => p.ChargeSessionAsync(_userId, It.IsAny<Guid>(), 225m, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ValidInput_SavesChanges()
+    {
+        Setup();
+
+        await _service.CreateAsync(_userId, ValidDto());
+
+        _mockContext.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/CyberZone.Tests/Infrastructure/Services/ClubServiceAdminActionsTests.cs
+++ b/CyberZone.Tests/Infrastructure/Services/ClubServiceAdminActionsTests.cs
@@ -19,7 +19,7 @@ public class ClubServiceAdminActionsTests
     {
         _mockContext = new Mock<CyberZone.Application.Interfaces.IApplicationDbContext>();
         var logger = new Mock<ILogger<ClubService>>();
-        _clubService = new ClubService(_mockContext.Object, logger.Object);
+        _clubService = new ClubService(_mockContext.Object, logger.Object, new NoOpCacheService(), CacheTestHelper.DefaultOptions());
     }
 
     [Fact]

--- a/MVC/Controllers/AccountController.cs
+++ b/MVC/Controllers/AccountController.cs
@@ -22,6 +22,7 @@ public class AccountController : Controller
     private readonly CyberZoneDbContext _context;
     private readonly IWebHostEnvironment _environment;
     private readonly IReviewService _reviewService;
+    private readonly ICacheService _cache;
 
     public AccountController(
         UserManager<User> userManager,
@@ -30,7 +31,8 @@ public class AccountController : Controller
         PaymentService paymentService,
         CyberZoneDbContext context,
         IWebHostEnvironment environment,
-        IReviewService reviewService)
+        IReviewService reviewService,
+        ICacheService cache)
     {
         _userManager = userManager;
         _signInManager = signInManager;
@@ -39,6 +41,7 @@ public class AccountController : Controller
         _context = context;
         _environment = environment;
         _reviewService = reviewService;
+        _cache = cache;
     }
 
     [HttpGet]
@@ -541,15 +544,32 @@ public class AccountController : Controller
 
         if (expiredSessions.Any())
         {
+            var affectedClubs = new HashSet<Guid>();
             foreach (var session in expiredSessions)
             {
                 session.EndSession(); // Викликаємо доменний метод (рахує гроші, міняє статус)
 
                 // Звільняємо ПК
                 if (session.Hardware != null)
+                {
                     session.Hardware.Status = CyberZone.Domain.Enums.HardwareStatus.Available;
+                    affectedClubs.Add(session.Hardware.ClubId);
+                }
+
+                // Закриваємо пов'язаний Booking
+                var relatedBooking = await _context.Bookings
+                    .Where(b => b.HardwareId == session.HardwareId
+                             && b.UserId == session.UserId
+                             && b.Status == CyberZone.Domain.Enums.BookingStatus.Active)
+                    .OrderByDescending(b => b.StartTime)
+                    .FirstOrDefaultAsync();
+                if (relatedBooking != null)
+                    relatedBooking.Status = CyberZone.Domain.Enums.BookingStatus.Completed;
             }
             await _context.SaveChangesAsync(); // Зберігаємо зміни в базу
+
+            foreach (var clubId in affectedClubs)
+                _cache.Remove(CyberZone.Application.Interfaces.CacheKeys.ClubMap(clubId));
         }
 
         var viewModels = new List<SessionItemViewModel>();
@@ -655,11 +675,18 @@ public class AccountController : Controller
             var plannedDuration = booking.EndTime - booking.StartTime;
             newSession.EndTime = newSession.StartTime.Add(plannedDuration);
 
+            Guid? clubId = null;
             if (booking.Hardware != null)
+            {
                 booking.Hardware.Status = CyberZone.Domain.Enums.HardwareStatus.Busy;
+                clubId = booking.Hardware.ClubId;
+            }
 
             _context.GamingSessions.Add(newSession);
             await _context.SaveChangesAsync();
+
+            if (clubId.HasValue)
+                _cache.Remove(CyberZone.Application.Interfaces.CacheKeys.ClubMap(clubId.Value));
         }
 
         return RedirectToAction("Sessions");
@@ -695,11 +722,28 @@ public class AccountController : Controller
         {
             session.EndSession(); // Викликаємо твій доменний метод розрахунку
 
+            Guid? clubId = null;
             // Звільняємо ПК
             if (session.Hardware != null)
+            {
                 session.Hardware.Status = CyberZone.Domain.Enums.HardwareStatus.Available;
+                clubId = session.Hardware.ClubId;
+            }
+
+            // Закриваємо пов'язаний Booking (щоб не блокував overlap при новому бронюванні)
+            var relatedBooking = await _context.Bookings
+                .Where(b => b.HardwareId == session.HardwareId
+                         && b.UserId == session.UserId
+                         && b.Status == CyberZone.Domain.Enums.BookingStatus.Active)
+                .OrderByDescending(b => b.StartTime)
+                .FirstOrDefaultAsync();
+            if (relatedBooking != null)
+                relatedBooking.Status = CyberZone.Domain.Enums.BookingStatus.Completed;
 
             await _context.SaveChangesAsync();
+
+            if (clubId.HasValue)
+                _cache.Remove(CyberZone.Application.Interfaces.CacheKeys.ClubMap(clubId.Value));
         }
 
         return RedirectToAction("Sessions");

--- a/MVC/Controllers/BookingController.cs
+++ b/MVC/Controllers/BookingController.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+using CyberZone.Application.DTOs;
+using CyberZone.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MVC.Controllers;
+
+[Authorize]
+public class BookingController : Controller
+{
+    private readonly IBookingService _bookingService;
+
+    public BookingController(IBookingService bookingService)
+    {
+        _bookingService = bookingService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Create(Guid clubId, Guid hardwareId)
+    {
+        var userId = GetUserId();
+        if (userId is null) return RedirectToAction("Login", "Account");
+
+        var result = await _bookingService.PrepareFormAsync(userId.Value, clubId, hardwareId);
+        if (result.IsFailure)
+        {
+            TempData["Error"] = result.Error;
+            return RedirectToAction("Map", "Home", new { id = clubId });
+        }
+
+        return View(result.Value);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(BookNowDto dto)
+    {
+        var userId = GetUserId();
+        if (userId is null) return RedirectToAction("Login", "Account");
+
+        if (!ModelState.IsValid)
+        {
+            var reload = await _bookingService.PrepareFormAsync(userId.Value, dto.ClubId, dto.HardwareId);
+            if (reload.IsSuccess)
+            {
+                reload.Value.TariffId = dto.TariffId;
+                reload.Value.StartTime = dto.StartTime;
+                reload.Value.Hours = dto.Hours;
+                reload.Value.Notes = dto.Notes;
+                return View(reload.Value);
+            }
+            return RedirectToAction("Map", "Home", new { id = dto.ClubId });
+        }
+
+        var result = await _bookingService.CreateAsync(userId.Value, dto);
+        if (result.IsFailure)
+        {
+            ModelState.AddModelError("", result.Error ?? "Не вдалося створити бронювання.");
+            var reload = await _bookingService.PrepareFormAsync(userId.Value, dto.ClubId, dto.HardwareId);
+            return View(reload.IsSuccess ? reload.Value : dto);
+        }
+
+        TempData["Success"] = "Бронювання успішно створено!";
+        return RedirectToAction("Sessions", "Account");
+    }
+
+    private Guid? GetUserId()
+    {
+        var raw = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return Guid.TryParse(raw, out var id) ? id : null;
+    }
+}

--- a/MVC/Controllers/HomeController.cs
+++ b/MVC/Controllers/HomeController.cs
@@ -73,12 +73,6 @@ public class HomeController : Controller
         return View(result.Value);
     }
 
-    [HttpGet]
-    public IActionResult Booking(Guid id, Guid? hardwareId)
-    {
-        return RedirectToAction(nameof(Map), new { id });
-    }
-
     [Authorize(Roles = "Admin, Staff")]
     [HttpGet]
     public async Task<IActionResult> Edit(Guid id)

--- a/MVC/Views/Booking/Create.cshtml
+++ b/MVC/Views/Booking/Create.cshtml
@@ -1,0 +1,123 @@
+@using CyberZone.Application.DTOs
+@model BookNowDto
+@{
+    ViewData["Title"] = $"Бронювання ПК {Model.PcNumber}";
+    Layout = null;
+    var minPrice = Model.AvailableTariffs.Min(t => t.PricePerHour);
+}
+
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - CyberZone</title>
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/clubmap.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/booking.css" asp-append-version="true" />
+</head>
+<body class="map-page">
+
+<partial name="_Header" />
+
+<div class="breadcrumb-bar">
+    <a asp-controller="Home" asp-action="Catalog">Каталог клубів</a>
+    <span class="breadcrumb-sep">›</span>
+    <a asp-controller="Home" asp-action="Details" asp-route-id="@Model.ClubId">@Model.ClubName</a>
+    <span class="breadcrumb-sep">›</span>
+    <a asp-controller="Home" asp-action="Map" asp-route-id="@Model.ClubId">Інтерактивна мапа</a>
+    <span class="breadcrumb-sep">›</span>
+    <span class="breadcrumb-current">Бронювання ПК @Model.PcNumber</span>
+</div>
+
+<div class="booking-container">
+    <div class="booking-card">
+        <div class="booking-header">
+            <h1>Бронювання</h1>
+            <div class="booking-sub">@Model.ClubName · ПК <strong>@Model.PcNumber</strong></div>
+        </div>
+
+        @if (TempData["Error"] is string err)
+        {
+            <div class="booking-alert error">@err</div>
+        }
+
+        <div asp-validation-summary="ModelOnly" class="booking-alert error"></div>
+
+        <form asp-action="Create" method="post" id="booking-form">
+            @Html.AntiForgeryToken()
+            <input type="hidden" asp-for="ClubId" />
+            <input type="hidden" asp-for="HardwareId" />
+            <input type="hidden" asp-for="PcNumber" />
+            <input type="hidden" asp-for="ClubName" />
+
+            <div class="form-row">
+                <label asp-for="TariffId">Тариф</label>
+                <select asp-for="TariffId" id="tariff-select" class="form-input">
+                    @foreach (var t in Model.AvailableTariffs)
+                    {
+                        var priceInv = t.PricePerHour.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                        <option value="@t.Id" data-price="@priceInv">
+                            @t.Name (@t.Type) — @t.PricePerHour.ToString("0") ₴/год
+                        </option>
+                    }
+                </select>
+                <span asp-validation-for="TariffId" class="field-error"></span>
+            </div>
+
+            <div class="form-row">
+                <label asp-for="StartTime">Час початку</label>
+                <input asp-for="StartTime" type="datetime-local" class="form-input" id="start-input" />
+                <span asp-validation-for="StartTime" class="field-error"></span>
+            </div>
+
+            <div class="form-row">
+                <label asp-for="Hours">Тривалість (годин)</label>
+                <input asp-for="Hours" type="number" min="1" max="24" class="form-input" id="hours-input" />
+                <span asp-validation-for="Hours" class="field-error"></span>
+            </div>
+
+            <div class="form-row">
+                <label asp-for="Notes">Коментар (необов'язково)</label>
+                <textarea asp-for="Notes" rows="2" class="form-input"></textarea>
+            </div>
+
+            <div class="booking-summary">
+                <div class="summary-row">
+                    <span>Вартість:</span>
+                    <span class="summary-value"><span id="summary-cost">@minPrice.ToString("0", System.Globalization.CultureInfo.InvariantCulture)</span> ₴</span>
+                </div>
+                <div class="summary-row">
+                    <span>Ваш баланс:</span>
+                    <span class="summary-value">@Model.UserBalance.ToString("0.00") ₴</span>
+                </div>
+            </div>
+
+            <div class="booking-actions">
+                <a asp-controller="Home" asp-action="Map" asp-route-id="@Model.ClubId" class="btn-ghost">Назад</a>
+                <button type="submit" class="btn-primary">Підтвердити бронювання</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+    (function () {
+        const tariff = document.getElementById('tariff-select');
+        const hours = document.getElementById('hours-input');
+        const cost = document.getElementById('summary-cost');
+
+        function recalc() {
+            const price = Number(tariff.options[tariff.selectedIndex].dataset.price || 0);
+            const h = Math.max(1, Math.min(24, Number(hours.value || 1)));
+            cost.textContent = (price * h).toFixed(0);
+        }
+
+        tariff.addEventListener('change', recalc);
+        hours.addEventListener('input', recalc);
+        recalc();
+    })();
+</script>
+
+</body>
+</html>

--- a/MVC/Views/Home/Map.cshtml
+++ b/MVC/Views/Home/Map.cshtml
@@ -198,7 +198,7 @@
                     ttBtn.classList.remove('disabled');
                     ttBtn.removeAttribute('aria-disabled');
                     ttBtn.textContent = 'Забронювати';
-                    ttBtn.href = '/Home/Booking/' + clubId + '?hardwareId=' + hwId;
+                    ttBtn.href = '/Booking/Create?clubId=' + clubId + '&hardwareId=' + hwId;
                 } else {
                     ttBtn.classList.add('disabled');
                     ttBtn.setAttribute('aria-disabled', 'true');

--- a/MVC/wwwroot/css/booking.css
+++ b/MVC/wwwroot/css/booking.css
@@ -1,0 +1,142 @@
+.booking-container {
+    padding: 40px 20px;
+    display: flex;
+    justify-content: center;
+}
+
+.booking-card {
+    width: 100%;
+    max-width: 560px;
+    background: #0f1f2d;
+    border: 2px solid #3fb8ff;
+    border-radius: 12px;
+    padding: 28px 32px;
+    color: #e4ecf4;
+    box-shadow: 0 0 40px rgba(63, 184, 255, 0.08);
+}
+
+.booking-header h1 {
+    font-family: 'Rajdhani', 'Inter', sans-serif;
+    font-size: 28px;
+    margin: 0 0 6px;
+    color: #d6ff3f;
+}
+
+.booking-sub {
+    color: #9fb1c6;
+    font-size: 14px;
+    margin-bottom: 24px;
+}
+
+.booking-alert {
+    padding: 10px 14px;
+    border-radius: 6px;
+    margin-bottom: 18px;
+    font-size: 14px;
+}
+
+.booking-alert.error {
+    background: rgba(224, 91, 111, 0.12);
+    border: 1px solid rgba(224, 91, 111, 0.4);
+    color: #ff8699;
+}
+
+.booking-alert:empty {
+    display: none;
+}
+
+.form-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 16px;
+}
+
+.form-row label {
+    font-size: 13px;
+    color: #9fb1c6;
+    font-weight: 600;
+}
+
+.form-input {
+    background: #132433;
+    border: 1px solid #2a3b4f;
+    color: #e4ecf4;
+    padding: 10px 12px;
+    border-radius: 6px;
+    font-family: 'Inter', sans-serif;
+    font-size: 14px;
+    box-sizing: border-box;
+    width: 100%;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: #3fb8ff;
+}
+
+textarea.form-input {
+    resize: vertical;
+    min-height: 48px;
+}
+
+.field-error {
+    color: #ff8699;
+    font-size: 12px;
+}
+
+.booking-summary {
+    background: #132433;
+    border-radius: 8px;
+    padding: 14px 16px;
+    margin: 20px 0;
+}
+
+.summary-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 0;
+    font-size: 14px;
+    color: #9fb1c6;
+}
+
+.summary-value {
+    color: #e4ecf4;
+    font-weight: 600;
+}
+
+.booking-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+}
+
+.btn-primary,
+.btn-ghost {
+    padding: 10px 22px;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+    text-decoration: none;
+    border: none;
+    font-family: 'Inter', sans-serif;
+}
+
+.btn-primary {
+    background: linear-gradient(91.95deg, #D6FF3F 2.89%, #E05BBE 97.05%);
+    color: #0b1720;
+}
+
+.btn-primary:hover { opacity: 0.9; }
+
+.btn-ghost {
+    background: transparent;
+    border: 1px solid #3a4b5f;
+    color: #9fb1c6;
+}
+
+.btn-ghost:hover {
+    border-color: #3fb8ff;
+    color: #e4ecf4;
+}


### PR DESCRIPTION
Implements a complete booking workflow for reserving PCs in clubs:
- Adds BookNowDto, TariffOption, IBookingService, and IPaymentService
- Implements BookingService with validation, overlap checks, and payment
- Registers new services in DI
- Adds BookingController and strongly-typed Create.cshtml booking form
- Updates club map to use new booking route
- Integrates booking/session completion with cache invalidation
- Adds comprehensive BookingService unit tests
- Removes obsolete /Home/Booking action

This provides a robust, user-friendly, and well-tested booking experience.