### PR TITLE
Add per-IP rate limiting filter and 429 error handling

### DIFF
--- a/MVC/Controllers/AccountController.cs
+++ b/MVC/Controllers/AccountController.cs
@@ -216,6 +216,7 @@ public class AccountController : Controller
 
     [HttpPost]
     [Authorize]
+    [MVC.Filters.RateLimit(3)]  // max 3 top-up attempts per minute per IP
     public async Task<IActionResult> TopUp(TopUpViewModel model)
     {
         if (!ModelState.IsValid) return View(model);

--- a/MVC/Controllers/BookingController.cs
+++ b/MVC/Controllers/BookingController.cs
@@ -3,6 +3,7 @@ using CyberZone.Application.DTOs;
 using CyberZone.Application.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using MVC.Filters;
 
 namespace MVC.Controllers;
 
@@ -34,6 +35,7 @@ public class BookingController : Controller
 
     [HttpPost]
     [ValidateAntiForgeryToken]
+    [RateLimit(5)]  // max 5 booking attempts per minute per IP
     public async Task<IActionResult> Create(BookNowDto dto)
     {
         var userId = GetUserId();

--- a/MVC/Controllers/DealsController.cs
+++ b/MVC/Controllers/DealsController.cs
@@ -1,5 +1,6 @@
 using CyberZone.Application.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using MVC.Filters;
 
 namespace MVC.Controllers;
 
@@ -13,6 +14,7 @@ public class DealsController : Controller
     }
 
     [HttpGet]
+    [RateLimit(20)]  // cap hits to the upstream CheapShark API per IP
     public async Task<IActionResult> Index(string sortBy = "Savings", int pageSize = 30, CancellationToken ct = default)
     {
         var result = await _dealsService.GetDealsAsync(pageSize, sortBy, ct);

--- a/MVC/Controllers/HomeController.cs
+++ b/MVC/Controllers/HomeController.cs
@@ -38,6 +38,14 @@ public class HomeController : Controller
         return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
     }
 
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    public IActionResult RateLimited(int retryAfter = 60)
+    {
+        Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        ViewData["RetryAfter"] = retryAfter;
+        return View();
+    }
+
     public async Task<IActionResult> Catalog()
     {
         var result = await _clubService.GetClubsForCatalogAsync();

--- a/MVC/Filters/RateLimitAttribute.cs
+++ b/MVC/Filters/RateLimitAttribute.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace MVC.Filters;
+
+/// <summary>
+/// Throttles requests per client IP using a sliding 1-minute window.
+/// Apply as [RateLimit(10)] on controllers/actions. Requires IMemoryCache in DI.
+/// </summary>
+/// <example>
+///     [RateLimit(5)]          // max 5 requests per minute per IP per route
+///     public IActionResult Index() { ... }
+/// </example>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+public class RateLimitAttribute : Attribute, IAsyncActionFilter
+{
+    private const string CacheKeyPrefix = "rl:";
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
+
+    /// <summary>Maximum requests per window (per IP + bucket).</summary>
+    public int Limit { get; }
+
+    /// <summary>Optional bucket suffix — lets you share the counter across actions.</summary>
+    public string? Bucket { get; set; }
+
+    public RateLimitAttribute(int limit)
+    {
+        if (limit < 1) throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be >= 1");
+        Limit = limit;
+    }
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        var services = context.HttpContext.RequestServices;
+        var cache = services.GetRequiredService<IMemoryCache>();
+        var logger = services.GetRequiredService<ILogger<RateLimitAttribute>>();
+
+        var ip = ResolveClientIp(context.HttpContext);
+        var bucket = Bucket ?? $"{context.RouteData.Values["controller"]}/{context.RouteData.Values["action"]}";
+        var key = $"{CacheKeyPrefix}{ip}:{bucket}";
+
+        var now = DateTimeOffset.UtcNow;
+
+        // Stored value: queue of timestamps for the last minute. ConcurrentQueue for thread safety.
+        var timestamps = cache.GetOrCreate(key, entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = Window * 2;
+            return new ConcurrentQueue<DateTimeOffset>();
+        })!;
+
+        // Evict old entries outside the window.
+        while (timestamps.TryPeek(out var oldest) && now - oldest > Window)
+            timestamps.TryDequeue(out _);
+
+        if (timestamps.Count >= Limit)
+        {
+            logger.LogWarning(
+                "Rate limit exceeded: IP {Ip}, bucket {Bucket}, limit {Limit}/min",
+                ip, bucket, Limit);
+
+            var retryAfter = timestamps.TryPeek(out var earliest)
+                ? Math.Max(1, (int)(Window - (now - earliest)).TotalSeconds)
+                : 60;
+            context.HttpContext.Response.Headers["Retry-After"] = retryAfter.ToString();
+
+            if (IsApiRequest(context.HttpContext))
+            {
+                context.Result = new ObjectResult(new
+                {
+                    error = "Too many requests",
+                    retryAfterSeconds = retryAfter
+                })
+                {
+                    StatusCode = StatusCodes.Status429TooManyRequests
+                };
+            }
+            else
+            {
+                context.Result = new RedirectToActionResult("RateLimited", "Home", new { retryAfter });
+            }
+            return;
+        }
+
+        timestamps.Enqueue(now);
+        await next();
+    }
+
+    private static string ResolveClientIp(HttpContext ctx)
+    {
+        // Honour X-Forwarded-For only if the app is explicitly behind a proxy.
+        // For local/dev, use the direct connection.
+        var forwarded = ctx.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(forwarded))
+            return forwarded.Split(',')[0].Trim();
+
+        return ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+    }
+
+    private static bool IsApiRequest(HttpContext ctx)
+    {
+        return ctx.Request.Path.StartsWithSegments("/api")
+            || ctx.Request.Headers.Accept.ToString().Contains("application/json", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/MVC/Views/Home/RateLimited.cshtml
+++ b/MVC/Views/Home/RateLimited.cshtml
@@ -1,0 +1,110 @@
+@{
+    ViewData["Title"] = "Занадто багато запитів";
+    Layout = null;
+    var retryAfter = ViewData["RetryAfter"] as int? ?? 60;
+}
+
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - CyberZone</title>
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <style>
+        body {
+            background: #0b1720;
+            color: #e4ecf4;
+            font-family: 'Inter', sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .rl-card {
+            max-width: 520px;
+            background: #0f1f2d;
+            border: 2px solid #e05bbe;
+            border-radius: 12px;
+            padding: 36px 40px;
+            text-align: center;
+            box-shadow: 0 0 40px rgba(224, 91, 190, 0.12);
+        }
+
+        .rl-icon {
+            font-size: 56px;
+            margin-bottom: 12px;
+        }
+
+        .rl-title {
+            font-family: 'Rajdhani', sans-serif;
+            font-size: 26px;
+            color: #e05bbe;
+            margin: 0 0 10px;
+        }
+
+        .rl-body {
+            color: #9fb1c6;
+            font-size: 14px;
+            line-height: 1.5;
+            margin: 0 0 20px;
+        }
+
+        .rl-retry {
+            background: #132433;
+            border: 1px solid #2a3b4f;
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin: 16px 0;
+            font-size: 13px;
+            color: #e4ecf4;
+        }
+
+        .rl-retry strong { color: #d6ff3f; }
+
+        .rl-back {
+            display: inline-block;
+            padding: 10px 22px;
+            border-radius: 6px;
+            background: linear-gradient(91.95deg, #D6FF3F 2.89%, #E05BBE 97.05%);
+            color: #0b1720;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .rl-back:hover { opacity: 0.9; }
+    </style>
+</head>
+<body>
+    <div class="rl-card">
+        <div class="rl-icon">⏱️</div>
+        <h1 class="rl-title">Занадто багато запитів</h1>
+        <p class="rl-body">
+            Ви перевищили ліміт запитів до цієї дії. Це захист від випадкових подвійних
+            натискань та зловживань. Будь ласка, зачекайте і спробуйте знову.
+        </p>
+        <div class="rl-retry">
+            Повторіть через <strong id="rl-seconds">@retryAfter</strong> сек.
+        </div>
+        <a href="/" class="rl-back">На головну</a>
+    </div>
+
+    <script>
+        (function () {
+            const el = document.getElementById('rl-seconds');
+            let remaining = Number(el.textContent) || 60;
+            const timer = setInterval(() => {
+                remaining -= 1;
+                if (remaining <= 0) {
+                    clearInterval(timer);
+                    el.textContent = '0';
+                    return;
+                }
+                el.textContent = remaining;
+            }, 1000);
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Introduced RateLimitAttribute for per-IP throttling on key actions using IMemoryCache and a sliding 1-minute window. Applied rate limits to top-up, booking, and deals endpoints. Added RateLimited action and Razor view to display a user-friendly 429 error page with retry countdown. API requests now receive JSON 429 responses; web requests are redirected to the error page.