### PR TITLE
Add real-time notifications via BackgroundService + SignalR

### DIFF
--- a/CyberZone.Application/DTOs/NotificationDto.cs
+++ b/CyberZone.Application/DTOs/NotificationDto.cs
@@ -1,0 +1,9 @@
+namespace CyberZone.Application.DTOs;
+
+public class NotificationDto
+{
+    public string Title { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string Level { get; set; } = "info";
+    public DateTime TimestampUtc { get; set; } = DateTime.UtcNow;
+}

--- a/CyberZone.Infrastructure/DependencyInjection.cs
+++ b/CyberZone.Infrastructure/DependencyInjection.cs
@@ -89,6 +89,9 @@ public static class DependencyInjection
 
         services.AddScoped<IDealsService, DealsService>();
 
+        // Real-time notifications: polls DB every 30s and pushes via SignalR.
+        services.AddHostedService<Realtime.NotificationPollingService>();
+
         return services;
     }
 }

--- a/CyberZone.Infrastructure/Realtime/NotificationHub.cs
+++ b/CyberZone.Infrastructure/Realtime/NotificationHub.cs
@@ -1,0 +1,35 @@
+using System.Security.Claims;
+using CyberZone.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.SignalR;
+
+namespace CyberZone.Infrastructure.Realtime;
+
+[Authorize]
+public class NotificationHub : Hub
+{
+    private readonly UserManager<User> _userManager;
+
+    public NotificationHub(UserManager<User> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public override async Task OnConnectedAsync()
+    {
+        var userId = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!string.IsNullOrEmpty(userId))
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, $"user-{userId}");
+
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user?.ManagedClubId is { } clubId && clubId != Guid.Empty)
+            {
+                await Groups.AddToGroupAsync(Context.ConnectionId, $"club-{clubId}");
+            }
+        }
+
+        await base.OnConnectedAsync();
+    }
+}

--- a/CyberZone.Infrastructure/Realtime/NotificationPollingService.cs
+++ b/CyberZone.Infrastructure/Realtime/NotificationPollingService.cs
@@ -1,0 +1,158 @@
+using CyberZone.Application.DTOs;
+using CyberZone.Domain.Enums;
+using CyberZone.Infrastructure.Persistence;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace CyberZone.Infrastructure.Realtime;
+
+public class NotificationPollingService : BackgroundService
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan SessionWarningWindowStart = TimeSpan.FromMinutes(4);
+    private static readonly TimeSpan SessionWarningWindowEnd = TimeSpan.FromMinutes(5);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<NotificationPollingService> _logger;
+
+    private readonly HashSet<Guid> _sentSessionWarningIds = [];
+    private readonly HashSet<Guid> _sentBookingIds = [];
+    private readonly HashSet<Guid> _sentOrderIds = [];
+    private DateTime _lastPollUtc = DateTime.UtcNow;
+
+    public NotificationPollingService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<NotificationPollingService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("NotificationPollingService started, polling every {Seconds}s", PollInterval.TotalSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await PollOnceAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Notification poll iteration failed");
+            }
+
+            try
+            {
+                await Task.Delay(PollInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task PollOnceAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<CyberZoneDbContext>();
+        var hub = scope.ServiceProvider.GetRequiredService<IHubContext<NotificationHub>>();
+
+        var now = DateTime.UtcNow;
+        var windowStart = now.Add(SessionWarningWindowStart);
+        var windowEnd = now.Add(SessionWarningWindowEnd);
+
+        var endingSessions = await db.GamingSessions
+            .Include(s => s.Hardware)
+            .Where(s => s.Status == SessionStatus.Active
+                     && s.EndTime.HasValue
+                     && s.EndTime.Value >= windowStart
+                     && s.EndTime.Value <= windowEnd)
+            .ToListAsync(ct);
+
+        foreach (var session in endingSessions)
+        {
+            if (!_sentSessionWarningIds.Add(session.Id)) continue;
+
+            var pc = session.Hardware?.PcNumber ?? "ПК";
+            await hub.Clients.Group($"user-{session.UserId}").SendAsync(
+                "notify",
+                new NotificationDto
+                {
+                    Title = "Сесія закінчується",
+                    Message = $"Ваша сесія на {pc} закінчується через 5 хв.",
+                    Level = "warning"
+                },
+                ct);
+        }
+
+        var newBookings = await db.Bookings
+            .Include(b => b.Hardware)
+            .Include(b => b.User)
+            .Where(b => b.CreatedAt > _lastPollUtc && b.Status == BookingStatus.Pending)
+            .ToListAsync(ct);
+
+        foreach (var booking in newBookings)
+        {
+            if (!_sentBookingIds.Add(booking.Id)) continue;
+            if (booking.Hardware is null) continue;
+
+            var clubId = booking.Hardware.ClubId;
+            var userName = booking.User?.UserName ?? "клієнт";
+            await hub.Clients.Group($"club-{clubId}").SendAsync(
+                "notify",
+                new NotificationDto
+                {
+                    Title = "Нове бронювання",
+                    Message = $"{userName} забронював {booking.Hardware.PcNumber} на {booking.StartTime.ToLocalTime():HH:mm}.",
+                    Level = "info"
+                },
+                ct);
+        }
+
+        var newOrders = await db.Orders
+            .Include(o => o.User)
+            .Include(o => o.Items)
+                .ThenInclude(i => i.MenuItem)
+            .Where(o => o.CreatedAt > _lastPollUtc && o.Status == OrderStatus.Pending)
+            .ToListAsync(ct);
+
+        foreach (var order in newOrders)
+        {
+            if (!_sentOrderIds.Add(order.Id)) continue;
+
+            var firstItem = order.Items.FirstOrDefault();
+            if (firstItem?.MenuItem is null) continue;
+
+            var clubId = firstItem.MenuItem.ClubId;
+            var itemSummary = string.Join(", ", order.Items
+                .Where(i => i.MenuItem is not null)
+                .Select(i => $"{i.MenuItem.Name} ×{i.Quantity}"));
+
+            await hub.Clients.Group($"club-{clubId}").SendAsync(
+                "notify",
+                new NotificationDto
+                {
+                    Title = "Нове замовлення",
+                    Message = $"Замовлення на {order.TotalAmount:0.##} грн: {itemSummary}",
+                    Level = "success"
+                },
+                ct);
+        }
+
+        _lastPollUtc = now;
+
+        if (_sentSessionWarningIds.Count > 10000) _sentSessionWarningIds.Clear();
+        if (_sentBookingIds.Count > 10000) _sentBookingIds.Clear();
+        if (_sentOrderIds.Count > 10000) _sentOrderIds.Clear();
+    }
+}

--- a/MVC/Program.cs
+++ b/MVC/Program.cs
@@ -8,6 +8,7 @@ using Serilog;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllersWithViews();
+builder.Services.AddSignalR();
 
 builder.Host.UseSerilog((context, configuration) =>
     configuration.ReadFrom.Configuration(context.Configuration));
@@ -77,5 +78,7 @@ app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}")
     .WithStaticAssets();
+
+app.MapHub<CyberZone.Infrastructure.Realtime.NotificationHub>("/hubs/notifications");
 
 await app.RunAsync();

--- a/MVC/Views/Shared/_Layout.cshtml
+++ b/MVC/Views/Shared/_Layout.cshtml
@@ -17,10 +17,17 @@
             @RenderBody()
         </main>
     </div>
-    
+
+    <div id="toast-container" class="toast-container position-fixed bottom-0 end-0 p-3"></div>
+
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
+    @if (User.Identity?.IsAuthenticated == true)
+    {
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.7/signalr.min.js"></script>
+        <script src="~/js/notifications.js" asp-append-version="true"></script>
+    }
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/MVC/wwwroot/js/notifications.js
+++ b/MVC/wwwroot/js/notifications.js
@@ -1,0 +1,56 @@
+(function () {
+    if (!window.signalR) {
+        console.warn("SignalR client not loaded; notifications disabled.");
+        return;
+    }
+
+    const container = document.getElementById("toast-container");
+    if (!container) return;
+
+    const levelToClass = {
+        info: "text-bg-info",
+        success: "text-bg-success",
+        warning: "text-bg-warning",
+        danger: "text-bg-danger"
+    };
+
+    function showToast(dto) {
+        const cls = levelToClass[dto.level] || levelToClass.info;
+        const el = document.createElement("div");
+        el.className = `toast ${cls} border-0`;
+        el.setAttribute("role", "alert");
+        el.setAttribute("aria-live", "assertive");
+        el.setAttribute("aria-atomic", "true");
+        el.innerHTML = `
+            <div class="d-flex">
+                <div class="toast-body">
+                    <strong>${escapeHtml(dto.title)}</strong><br>
+                    ${escapeHtml(dto.message)}
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>`;
+        container.appendChild(el);
+
+        const toast = new bootstrap.Toast(el, { delay: 6000 });
+        toast.show();
+        el.addEventListener("hidden.bs.toast", () => el.remove());
+    }
+
+    function escapeHtml(s) {
+        return String(s ?? "")
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+
+    const connection = new signalR.HubConnectionBuilder()
+        .withUrl("/hubs/notifications")
+        .withAutomaticReconnect()
+        .build();
+
+    connection.on("notify", showToast);
+
+    connection.start().catch(err => console.error("SignalR connect failed:", err));
+})();


### PR DESCRIPTION
Polls the DB every 30s for three events and pushes them to relevant browser tabs so users no longer need to refresh to see state changes:
  - gaming session ending in ~5 minutes (to the session owner)
  - new booking created in a club (to that club's staff)
  - new bar order placed (to that club's staff)

Routing uses SignalR groups: user-{id} for personal events and club-{id} joined on connect for staff with ManagedClubId set. Deduplication is kept in-memory in the hosted service.